### PR TITLE
Update install documentation for db_password_algorithm

### DIFF
--- a/app/views/install/index.php
+++ b/app/views/install/index.php
@@ -217,7 +217,7 @@ function config_form_row ($section, $var, $label, $type, $default_values, $choic
           <li>"<b>SHA1</b>" (unsecure)</li>
           <li>PHP Function name ex: "<b>methodName</b>"</li>
           <li>PHP Static method ex: "<b>ClassName::Method</b>"</li>
-          <li>Plain SQL ex: "<b>SHA1(CONCAT(salt_column, :password))</b>"</li>
+          <li>Plain SQL ex: "<b>SHA1(CONCAT(salt_column, :password))</b> (default)"</li>
         </ul>
       </div>
     </div>

--- a/app/views/install/index.php
+++ b/app/views/install/index.php
@@ -217,7 +217,7 @@ function config_form_row ($section, $var, $label, $type, $default_values, $choic
           <li>"<b>SHA1</b>" (unsecure)</li>
           <li>PHP Function name ex: "<b>methodName</b>"</li>
           <li>PHP Static method ex: "<b>ClassName::Method</b>"</li>
-          <li>Plain SQL ex: "<b>password=SHA1(CONCAT(salt_column, :password))</b>"</li>
+          <li>Plain SQL ex: "<b>SHA1(CONCAT(salt_column, :password))</b>"</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
I just installed for the first time FileZ, and I had trouble configuring the db_password_algorithm value:
I first tried with `password=SHA1(CONCAT(salt_column, :password))`, then when I checked the db schema `password=SHA1(CONCAT(salt, :password))`, and finally after checking the code in Database.php I understood I needed `SHA1(CONCAT(salt, :password))`.

In the commits I kept `salt_column` because the other examples are also meta and not literal.
