### PR TITLE
Fix undefined variables in loginForm.php

### DIFF
--- a/app/controllers/Auth.php
+++ b/app/controllers/Auth.php
@@ -27,12 +27,14 @@ class App_Controller_Auth extends Fz_Controller {
             fz_force_https ();
 
 		if (isset($_SESSION['token']) && $_POST['token'] == $_SESSION['token']) {
-			set ('username', (array_key_exists ('username', $_POST) ?
-            $_POST['username'] : ''));
+			set_or_default ('username', $_POST['username'], '');
+		} else {
+			set ('username', '');
 		}
 
 		$token = md5(uniqid(rand(), true));
 		$_SESSION['token'] = $token;
+		set ('token', $token);
 
         return html ('auth/loginForm.php');
     }


### PR DESCRIPTION
'token' was never set() and 'username' was set only if 'token' would have been set.
Now both are always set.

This is a regression introduced by 1f1368c8927e629f7701ecbfd30a20c3f727b25d
