### PR TITLE
Correction quota input on User creation

### DIFF
--- a/app/views/user/create.php
+++ b/app/views/user/create.php
@@ -30,7 +30,7 @@
   </div>
   <div id="quota">
     <label for="input-quota"><?php echo __('Quota') ?> :</label>
-    <input type="text" id="input-quota" name="lastname" value="<?php echo fz_config_get('app', 'user_quota') ?>" alt="<?php echo __('Quota') ?>" maxlength="20" />
+    <input type="text" id="input-quota" name="quota" value="<?php echo fz_config_get('app', 'user_quota') ?>" alt="<?php echo __('Quota') ?>" maxlength="20" />
   </div>
 
   <div id="upload">


### PR DESCRIPTION
Quota input "name" parameter was set to "lastname" instead of "quota" on User creation
