### PR TITLE
Ajustement de FileZ pour le chargement de fichier de 2G à 10G

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,8 +14,8 @@
 
 <IfModule mod_php5.c>
   php_value file_uploads On
-  php_value upload_max_filesize 700M
-  php_value post_max_size       700M
+  php_value upload_max_filesize 0
+  php_value post_max_size       10737418240
   php_value max_input_time      1200
   php_value max_execution_time  1200
 </IfModule>

--- a/app/models/File.php
+++ b/app/models/File.php
@@ -156,9 +156,21 @@ class App_Model_File extends Fz_Db_Table_Row_Abstract {
      * @return void
      *
      */
-    public function setFileInfo (array $file) {
+    public function setFileInfo (array $file, $taille) {
         $this->file_name = $file ['name'];
         $this->file_size = $file ['size'];
+        
+        // Gestion de la taille réelle du fichier
+        if ($taille < 2147483648) {
+            $this->file_size = $taille;
+        }
+        elseif ($taille >= 2147483648 && $taille < 6442450944) {
+            $this->file_size = 4*1024*1024*1024 + $file ['size'];
+        }
+        else{
+            $this->file_size = 8*1024*1024*1024 + $file ['size'];
+        }
+
     }
 
     /**

--- a/app/views/main/_upload_form.php
+++ b/app/views/main/_upload_form.php
@@ -4,6 +4,10 @@
     <label for="file-input"><?php echo __r('File (Max size: %size%)', array ('size' => bytesToShorthand ($max_upload_size))) ?> :</label>
     <div id="input-file">
       <input type="file" id="file-input" name="file" value="" alt="<?php echo __('File') ?>" />
+      <p>
+        <input type="hidden" id="taille" name="taille"  value="" alt="" />
+        <label  id='textTailleMax' for="taille" style="display:none" ><?php echo(ini_get ('post_max_size')); ?></label>
+      </p>
     </div>
   </div>
   <div id="lifetime">
@@ -41,6 +45,7 @@
       <input type="password" id="input-password" name="password" class="password" autocomplete="off" size="5"/>
     </li>
   </ul>
+  <div id="sizeTooBig"><h2>La taille du fichier dépasse la limite autorisée !</h2></div>
   <div id="upload">
     <input type="submit" id="start-upload" name="upload" class="awesome blue large" value="&raquo; <?php echo __('Upload') ?>" />
     <div id="upload-loading"  style="display: none;"></div>
@@ -48,4 +53,29 @@
     <div id="upload-prospect" style="display: none;"></div>
   </div>
   </form>
+  
+  <script type="text/javascript">
+  $(document).ready(function(){
+    $('#sizeTooBig').hide();
+    $("#file-input").change(function(){
+      
+      var selectedFile = this.files[0].size;
+      var sizeMaxFile = $('#textTailleMax').html();
+      sizeMaxFile = parseInt(sizeMaxFile);
+      console.log(typeof(sizeMaxFile));
+
+      if(selectedFile > sizeMaxFile){
+        $('#sizeTooBig').fadeIn();
+        $('#start-upload').attr('disabled', true);
+      }
+      else{
+        $('#sizeTooBig').hide();
+        $('#start-upload').attr('disabled', false);
+      }
+
+
+      $("#taille").val(selectedFile);
+    });
+  });
+</script>
 

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -950,3 +950,22 @@ article.doc .img-block {
   text-align: center;
 	margin: 1em 0;
 }
+
+
+#sizeTooBig{
+  height: 45px;
+  margin-top: 10px;
+  margin-right: 4px;
+  margin-left: 4px;
+  display: none;
+  background: #f2e1dc;
+  -moz-border-radius:    8px;
+  -webkit-border-radius: 8px;
+  border-radius:         8px;
+}
+
+#sizeTooBig h2 {
+  padding-top: 15px;
+  text-align: center;
+  font-size: 1,25em;  
+}


### PR DESCRIPTION
---

Modification des fichiers pour prendre en compte le téléchargement de gros fichiers

---
## PROBLEME 1 : 

Les modifications apportées aux sources originales permettent l'upload de fichiers
de plus de 2G.

Avant les modifications, la taille un fichier de plus de 2G n'est pas correctement perçu par PHP, même avec les modifications du php.ini avec les valeurs suivantes : 

  php_value file_uploads On
  php_value upload_max_filesize 10737418240
  php_value post_max_size       10737418240
  php_value max_input_time      1200
  php_value max_execution_time  1200

Le téléchargement conduit à une erreur.
## RESOLUTION DU PROBLEME 1:

La modification du php.ini est obligatoire pour résoudre le problème sur Windows et Debian 7.
Néanmoins, Windows accepte la valeur upload_max_filesize : 10737418240, alors que Debian, CentOS et Ubuntu_Server 14.04 non.

La solution consiste à la mettre à '0', pour signifier l'infini.
## PROBLEME 2 :

Même si le téléchargement s'effectue dans de bonnes conditions avec les modifications si dessus, la prise en compte de la taille du fichier dans MySQL et sur l'interface de FileZ, n'est pas correcte et présente des valeurs négatives.

RESOLUTION DU PROBLEME 2 :

Au delà de 1073741824 octets, la valeur de $_POST['file']['size'] n'est pas correcte.
De plus, l'interprétation de cette valeur est différente pour des fichiers au delà de 4G et de 8G

Nous avons introduit un script jquery qui recherche la taille du fichier au moment de sa sélection.

Cette valeur est ensuite envoyée en POST et c'est elle qui sert de référence pour le calcul de la taille du fichier, 
du quota utilisateur etc...

PS : UN script a été ajouter, un peu à la sauvage dans le fichier _upload_form.php
Je n'avais pas le temps de le mettre ailleurs, mais je ferais la correction plus tard.
