### PR TITLE
Patch 1

### DIFF
--- a/app/controllers/Upload.php
+++ b/app/controllers/Upload.php
@@ -185,7 +185,7 @@ class App_Controller_Upload extends Fz_Controller {
         $file->setAvailableFrom ($availableFrom);
         $file->setAvailableUntil($availableUntil);
         $file->notify_uploader  = isset ($post['email-notifications']);
-        if (! empty ($post ['password']))
+        if (($post['use-password'] == 1) && (! empty ($post ['password'])))
             $file->setPassword  ($post ['password']);
 
         try {

--- a/app/views/main/_upload_form.php
+++ b/app/views/main/_upload_form.php
@@ -34,7 +34,8 @@
       </label>
     </li>
     <li id="option-use-password">
-      <input type="checkbox" name="use-password" id="use-password"/>
+      <input type="hidden" name="use-password" value="0" />
+      <input type="checkbox" name="use-password" id="use-password" value="1" />
       <label for="use-password" title="<?php echo __('Ask a password to people who will download your file') ?>">
         <?php echo __('Use a password to download') ?>
       </label>


### PR DESCRIPTION
If a browser has cached a user's password and is set to auto-fill passwords, it is possible to have a password set without the user intending to.  The password field on the upload form is filled out and submitted even though hidden.

This patch sets a value on the use-password checkbox and then validates that as intent before setting a password on an upload.
